### PR TITLE
Fix: Fix secureornot to true on textinput for password in LoginScreen

### DIFF
--- a/screens/unauthentication/LoginScreen.tsx
+++ b/screens/unauthentication/LoginScreen.tsx
@@ -52,7 +52,7 @@ export default function LoginScreen() {
           placeholder="Password"
           leftIcon={<TextInput.Icon icon={"lock"} />}
           rightIcon={<TextInput.Icon icon={"eye-off"} />}
-          secureOrNot={false}
+          secureOrNot={true}
         />
         <Text
           style={styles.text}


### PR DESCRIPTION
In this PR:
1. Changed secureOrnot to true on password textinput in LoginScreen