### PR TITLE
Fix: Add back author cards in HomeScreen

### DIFF
--- a/screens/authentication/Home/HomeScreen.tsx
+++ b/screens/authentication/Home/HomeScreen.tsx
@@ -67,6 +67,13 @@ export default function HomeScreen() {
             <Text variant="titleLarge" style={styles.largeTitles}>
               Popular Authors
             </Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <View style={styles.authorList}>
+                {popularAuthors.map((authorKey) => (
+                  <AuthorCard key={authorKey} authorKey={authorKey} />
+                ))}
+              </View>
+            </ScrollView>
           </View>
         </View>
       </KeyboardAvoidingView>


### PR DESCRIPTION
In this PR:
1. Added author cards back in HomeScreen since they were accidentally removed in earlier branch